### PR TITLE
removed scheme from admin_url to allow it to automatically choose

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -214,7 +214,7 @@ function poll_scripts() {
 	$pollbar = get_option('poll_bar');
 	wp_enqueue_script('wp-polls', plugins_url('wp-polls/polls-js.js'), array('jquery'), WP_POLLS_VERSION, true);
 	wp_localize_script('wp-polls', 'pollsL10n', array(
-		'ajax_url' => admin_url('admin-ajax.php', (is_ssl() ? 'https' : 'http')),
+		'ajax_url' => admin_url('admin-ajax.php'),
 		'text_wait' => __('Your last request is still being processed. Please wait a while ...', 'wp-polls'),
 		'text_valid' => __('Please choose a valid poll answer.', 'wp-polls'),
 		'text_multiple' => __('Maximum number of choices allowed: ', 'wp-polls'),
@@ -233,7 +233,7 @@ function poll_scripts_admin($hook_suffix) {
 		wp_enqueue_style('wp-polls-admin', plugins_url('wp-polls/polls-admin-css.css'), false, WP_POLLS_VERSION, 'all');
 		wp_enqueue_script('wp-polls-admin', plugins_url('wp-polls/polls-admin-js.js'), array('jquery'), WP_POLLS_VERSION, true);
 		wp_localize_script('wp-polls-admin', 'pollsAdminL10n', array(
-			'admin_ajax_url' => admin_url('admin-ajax.php', (is_ssl() ? 'https' : 'http')),
+			'admin_ajax_url' => admin_url('admin-ajax.php'),
 			'text_direction' => ('rtl' == $text_direction) ? 'left' : 'right',
 			'text_delete_poll' => __('Delete Poll', 'wp-polls'),
 			'text_no_poll_logs' => __('No poll logs available.', 'wp-polls'),


### PR DESCRIPTION
removed scheme from admin_url to allow it to automatically choose the correct scheme based on FORCE_SSL_ADMIN and is_ssl()

When FORCE_SSL_ADMIN is enabled, but the current page is not SSL, the "(is_ssl() ? 'https' : 'http')" logic causes an "http" URL to be generated when an "https" is supposed to be used.

http://codex.wordpress.org/Function_Reference/admin_url
