### PR TITLE
Resolve conflict with WP Super Cache

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -1306,13 +1306,6 @@ function vote_poll() {
 			exit();
 		}
 
-		// Verify Referer
-		if(!check_ajax_referer('poll_'.$poll_id.'-nonce', 'poll_'.$poll_id.'_nonce', false))
-		{
-			_e('Failed To Verify Referrer', 'wp-polls');
-			exit();
-		}
-
 		// Which View
 		switch($_REQUEST['view'])
 		{


### PR DESCRIPTION
Resolve conflict with WP Super Cache, see: https://wordpress.org/support/topic/plugin-wp-polls-failed-to-verify-referrer

If it is really necessary at this point to check the referer, so this should be done without a nonce.