### PR TITLE
restore current blog after each switch

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -1632,10 +1632,9 @@ function polls_activation( $network_wide )
 			{
 				switch_to_blog( $ms_site['blog_id'] );
 				polls_activate();
+				restore_current_blog();
 			}
 		}
-
-		restore_current_blog();
 	}
 	else
 	{


### PR DESCRIPTION
restoring only one time after few switches leaves blogs is some strange state, I think it should be restored after each switch (as staged in https://codex.wordpress.org/Function_Reference/restore_current_blog#Notes)
> restore_current_blog() should be called after every switch_to_blog().