### PR TITLE
change db prefix after blog site, optionally use one fixed prefix

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -41,10 +41,19 @@ function polls_textdomain() {
 
 
 ### Polls Table Name
-global $wpdb;
-$wpdb->pollsq   = $wpdb->prefix.'pollsq';
-$wpdb->pollsa   = $wpdb->prefix.'pollsa';
-$wpdb->pollsip  = $wpdb->prefix.'pollsip';
+add_action('switch_blog', 'poll_setup_tables_names');
+function poll_setup_tables_names(){
+	global $wpdb;
+	if(defined('POLLS_MOTHER_SITE')){
+		$prefix = $wpdb->get_blog_prefix(POLLS_MOTHER_SITE);
+	}else{
+		$prefix = $wpdb->prefix;
+	}
+	$wpdb->pollsq   = $prefix.'pollsq';
+	$wpdb->pollsa   = $prefix.'pollsa';
+	$wpdb->pollsip  = $prefix.'pollsip';
+}
+poll_setup_tables_names();
 
 
 ### Function: Poll Administration Menu


### PR DESCRIPTION
This issue is somehow related to #46, I have multisite (network) WP instalation, and wp-polls is networkwide activated. In activation hook there is loop over all sites and `polls_activate()` is called on each blog but `$wpdb` tables names are not updated so it connects to same tables over and over again. I think it is a bug because tables should be created in each blog (`wp_`, `wp_2_`, etc) but having all polls in one blog and having them accessible in all blogs was desired by me (it isn't a bug, it's a feature!), so I've added this config const `POLLS_MOTHER_SITE` (kill me for this name :P ) so when it is defined blog switches are ignored and all DB access is to one selected blog.
