### PR TITLE
SQL injection fixes.

### DIFF
--- a/polls-add.php
+++ b/polls-add.php
@@ -16,7 +16,7 @@ if(!empty($_POST['do'])) {
 		case __('Add Poll', 'wp-polls'):
 			check_admin_referer('wp-polls_add-poll');
 			// Poll Question
-			$pollq_question = addslashes( wp_kses_post( trim( $_POST['pollq_question'] ) ) );
+			$pollq_question = wp_kses_post( trim( $_POST['pollq_question'] ) );
 			if( ! empty( $pollq_question ) ) {
 				// Poll Start Date
 				$timestamp_sql = '';
@@ -57,19 +57,19 @@ if(!empty($_POST['do'])) {
 					$pollq_multiple = 0;
 				}
 				// Insert Poll
-				$add_poll_question = $wpdb->query("INSERT INTO $wpdb->pollsq VALUES (0, '$pollq_question', '$pollq_timestamp', 0, $pollq_active, '$pollq_expiry', $pollq_multiple, 0)");
+				$add_poll_question = $wpdb->query($wpdb->prepare("INSERT INTO $wpdb->pollsq VALUES (0, %s, %s, 0, %d, %s, %d, 0)", $pollq_question, $pollq_timestamp, $pollq_active, $pollq_expiry, $pollq_multiple));
 				if (!$add_poll_question) {
-					$text .= '<p style="color: red;">' . sprintf(__('Error In Adding Poll \'%s\'.', 'wp-polls'), stripslashes($pollq_question)) . '</p>';
+					$text .= '<p style="color: red;">' . sprintf(__('Error In Adding Poll \'%s\'.', 'wp-polls'), $pollq_question) . '</p>';
 				}
 				// Add Poll Answers
 				$polla_answers = $_POST['polla_answers'];
 				$polla_qid = intval($wpdb->insert_id);
 				foreach ($polla_answers as $polla_answer) {
-					$polla_answer = addslashes( wp_kses_post( trim( $polla_answer ) ) );
+					$polla_answer = wp_kses_post( trim( $polla_answer ) );
 					if( ! empty( $polla_answer ) ) {
-						$add_poll_answers = $wpdb->query("INSERT INTO $wpdb->pollsa VALUES (0, $polla_qid, '$polla_answer', 0)");
+						$add_poll_answers = $wpdb->query($wpdb->prepare("INSERT INTO $wpdb->pollsa VALUES (0, %d, %s, 0)", $polla_qid, $polla_answer));
 						if (!$add_poll_answers) {
-							$text .= '<p style="color: red;">' . sprintf(__('Error In Adding Poll\'s Answer \'%s\'.', 'wp-polls'), stripslashes($polla_answer)) . '</p>';
+							$text .= '<p style="color: red;">' . sprintf(__('Error In Adding Poll\'s Answer \'%s\'.', 'wp-polls'), $polla_answer) . '</p>';
 						}
 					} else {
 						$text .= '<p style="color: red;">' . __( 'Poll\'s Answer is empty.', 'wp-polls' ) . '</p>';
@@ -81,10 +81,10 @@ if(!empty($_POST['do'])) {
 				// If poll starts in the future use the correct poll ID
 				$latest_pollid = ( $latest_pollid < $polla_qid ) ? $polla_qid : $latest_pollid;
 				if ( empty( $text ) ) {
-					$text = '<p style="color: green;">' . sprintf( __( 'Poll \'%s\' (ID: %s) added successfully. Embed this poll with the shortcode: %s or go back to <a href="%s">Manage Polls</a>', 'wp-polls' ), stripslashes( $pollq_question ), $latest_pollid, '<input type="text" value=\'[poll id="' . $latest_pollid . '"]\' readonly="readonly" size="10" />', $base_page ) . '</p>';
+					$text = '<p style="color: green;">' . sprintf( __( 'Poll \'%s\' (ID: %s) added successfully. Embed this poll with the shortcode: %s or go back to <a href="%s">Manage Polls</a>', 'wp-polls' ), $pollq_question, $latest_pollid, '<input type="text" value=\'[poll id="' . $latest_pollid . '"]\' readonly="readonly" size="10" />', $base_page ) . '</p>';
 				} else {
 					if( $add_poll_question ) {
-						$text .= '<p style="color: green;">' . sprintf( __( 'Poll \'%s\' (ID: %s) (Shortcode: %s) added successfully, but there are some errors with the Poll\'s Answers. Embed this poll with the shortcode: %s or go back to <a href="%s">Manage Polls</a>', 'wp-polls' ), stripslashes( $pollq_question ), $latest_pollid, '<input type="text" value=\'[poll id="' . $latest_pollid . '"]\' readonly="readonly" size="10" />' ) .'</p>';
+						$text .= '<p style="color: green;">' . sprintf( __( 'Poll \'%s\' (ID: %s) (Shortcode: %s) added successfully, but there are some errors with the Poll\'s Answers. Embed this poll with the shortcode: %s or go back to <a href="%s">Manage Polls</a>', 'wp-polls' ), $pollq_question, $latest_pollid, '<input type="text" value=\'[poll id="' . $latest_pollid . '"]\' readonly="readonly" size="10" />' ) .'</p>';
 					}
 				}
 				do_action( 'wp_polls_add_poll', $latest_pollid );

--- a/polls-logs.php
+++ b/polls-logs.php
@@ -34,7 +34,8 @@ $poll_registered = $wpdb->get_var("SELECT COUNT(pollip_userid) FROM $wpdb->polls
 $poll_comments = $wpdb->get_var("SELECT COUNT(pollip_user) FROM $wpdb->pollsip WHERE pollip_qid = $poll_id AND pollip_user != '".__('Guest', 'wp-polls')."' AND pollip_userid = 0");
 $poll_guest = $wpdb->get_var("SELECT COUNT(pollip_user) FROM $wpdb->pollsip WHERE pollip_qid = $poll_id AND pollip_user = '".__('Guest', 'wp-polls')."'");
 $poll_totalrecorded = ($poll_registered+$poll_comments+$poll_guest);
-$poll_answers_data = $wpdb->get_results("SELECT polla_aid, polla_answers FROM $wpdb->pollsa WHERE polla_qid = $poll_id ORDER BY ".get_option('poll_ans_sortby').' '.get_option('poll_ans_sortorder'));
+list($order_by, $sort_order) = _polls_get_ans_sort();
+$poll_answers_data = $wpdb->get_results("SELECT polla_aid, polla_answers FROM $wpdb->pollsa WHERE polla_qid = $poll_id ORDER BY ".$order_by.' '.$sort_order);
 $poll_voters = $wpdb->get_col("SELECT DISTINCT pollip_user FROM $wpdb->pollsip WHERE pollip_qid = $poll_id AND pollip_user != '".__('Guest', 'wp-polls')."' ORDER BY pollip_user ASC");
 $poll_logs_count = $wpdb->get_var("SELECT COUNT(pollip_id) FROM $wpdb->pollsip WHERE pollip_qid = $poll_id");
 
@@ -79,7 +80,7 @@ if(!empty($_POST['do'])) {
 			$exclude_registered_2 = intval($_POST['exclude_registered_2']);
 			$exclude_comment_2 = intval($_POST['exclude_comment_2']);
 			$num_choices = intval($_POST['num_choices']);
-			$num_choices_sign = addslashes($_POST['num_choices_sign']);
+			$num_choices_sign = esc_sql($_POST['num_choices_sign']);
 			switch($num_choices_sign) {
 				case 'more':
 					$num_choices_sign_sql = '>';
@@ -113,7 +114,7 @@ if(!empty($_POST['do'])) {
 			$order_by = 'pollip_user, pollip_ip';
 			break;
 		case 3;
-			$what_user_voted = addslashes($_POST['what_user_voted']);
+			$what_user_voted = esc_sql($_POST['what_user_voted']);
 			$what_user_voted_sql = "AND pollip_user = '$what_user_voted'";
 			$order_by = 'pollip_user, pollip_ip';
 			break;

--- a/polls-manager.php
+++ b/polls-manager.php
@@ -42,7 +42,7 @@ if(!empty($_POST['do'])) {
 			// Poll Total Voters
 			$pollq_totalvoters = intval($_POST['pollq_totalvoters']);
 			// Poll Question
-			$pollq_question = addslashes( wp_kses_post( trim( $_POST['pollq_question'] ) ) );
+			$pollq_question = esc_sql( wp_kses_post( trim( $_POST['pollq_question'] ) ) );
 			// Poll Active
 			$pollq_active = intval($_POST['pollq_active']);
 			// Poll Start Date
@@ -105,7 +105,7 @@ if(!empty($_POST['do'])) {
 						$polla_aids[] = intval($get_polla_aid->polla_aid);
 				}
 				foreach($polla_aids as $polla_aid) {
-					$polla_answers = addslashes( wp_kses_post( trim( $_POST['polla_aid-'.$polla_aid] ) ) );
+					$polla_answers = esc_sql( wp_kses_post( trim( $_POST['polla_aid-'.$polla_aid]) ) );
 					$polla_votes = intval($_POST['polla_votes-'.$polla_aid]);
 					$edit_poll_answer = $wpdb->query("UPDATE $wpdb->pollsa SET polla_answers = '$polla_answers', polla_votes = $polla_votes WHERE polla_qid = $pollq_id AND polla_aid = $polla_aid");
 					if(!$edit_poll_answer) {
@@ -123,14 +123,14 @@ if(!empty($_POST['do'])) {
 				$i = 0;
 				$polla_answers_new_votes = $_POST['polla_answers_new_votes'];
 				foreach($polla_answers_new as $polla_answer_new) {
-					$polla_answer_new = addslashes( wp_kses_post( trim( $polla_answer_new ) ) );
+					$polla_answer_new = wp_kses_post( trim( $polla_answer_new ) );
 					if(!empty($polla_answer_new)) {
 						$polla_answer_new_vote = intval($polla_answers_new_votes[$i]);
-						$add_poll_answers = $wpdb->query("INSERT INTO $wpdb->pollsa VALUES (0, $pollq_id, '$polla_answer_new', $polla_answer_new_vote)");
+						$add_poll_answers = $wpdb->query($wpdb->prepare("INSERT INTO $wpdb->pollsa VALUES (0, %d, %s, %d)", $pollq_id, $polla_answer_new, $polla_answer_new_vote));
 						if(!$add_poll_answers) {
-							$text .= '<p style="color: red;">'.sprintf(__('Error In Adding Poll\'s Answer \'%s\'.', 'wp-polls'), stripslashes($polla_answer_new)).'</p>';
+							$text .= '<p style="color: red;">'.sprintf(__('Error In Adding Poll\'s Answer \'%s\'.', 'wp-polls'), $polla_answer_new).'</p>';
 						} else {
-							$text .= '<p style="color: green;">'.sprintf(__('Poll\'s Answer \'%s\' Added Successfully.', 'wp-polls'), stripslashes($polla_answer_new)).'</p>';
+							$text .= '<p style="color: green;">'.sprintf(__('Poll\'s Answer \'%s\' Added Successfully.', 'wp-polls'), $polla_answer_new).'</p>';
 						}
 					}
 					$i++;


### PR DESCRIPTION
This commit does the following:
Fix possible rDNS SQL injection (gethostbyaddr() - tough but possible to do; definitely not low-hanging fruit). Use $wpdb->prepare() where appropriate. Use esc_sql() instead of addslashes(). Whitelist ORDER BY and SORT BY SQL injection vectors.