### PR TITLE
 preventing cross site voting & validating answers

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -1237,7 +1237,6 @@ function cron_polls_place() {
     }
 }
 
-
 ### Funcion: Check All Polls Status To Check If It Expires
 add_action('polls_cron', 'cron_polls_status');
 function cron_polls_status() {
@@ -1316,6 +1315,9 @@ function vote_poll() {
                 do_action('wp_polls_vote_poll');
                 $poll_aid = $_POST["poll_$poll_id"];
                 $poll_aid_array = array_unique(array_map('intval', explode(',', $poll_aid)));
+                $isReal = intval( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->pollsa WHERE polla_aid = %d AND polla_qid", array($poll_aid,$poll_id) ) ) );
+		//checks if answer is acceptable.
+		if($isReal > 0){
                 if($poll_id > 0 && !empty($poll_aid_array) && check_allowtovote()) {
                     $is_poll_open = intval( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->pollsq WHERE pollq_id = %d AND pollq_active = 1", $poll_id ) ) );
                     if ( $is_poll_open > 0 ) {
@@ -1387,7 +1389,10 @@ function vote_poll() {
                     }  // End if($is_poll_open > 0)
                 } else {
                     printf(__('Invalid Poll ID. Poll ID #%s', 'wp-polls'), $poll_id);
-                } // End if($poll_id > 0 && !empty($poll_aid_array) && check_allowtovote())
+                    } // End if($poll_id > 0 && !empty($poll_aid_array) && check_allowtovote())
+		} else{
+		     printf(__('Invalid Answer to Poll ID #%s', 'wp-polls'), $poll_id);
+		} //End if(!isRealAnswer($poll_id,$poll_aid))
                 break;
             // Poll Result
             case 'result':


### PR DESCRIPTION
There is a current flaw in wp-polls that allows people to embed the following into a page:
http://example.com/wp-admin/admin-ajax.php?action=polls&view=process&poll_id=POLLID&poll_POLLID=ANSWER&poll_POLLID_nonce=POLLNONCE

This allows exploiters to get votes from people who have not even visited the WordPress site. I exploited this on a WordPress site, and got 318k votes by embedding the link into various forum signatures. However, since the poll answer is a GET variable, the actual answers went to 0%. It is because the votes were not counted as answers, but still added to the total votes. I added an if statement that checks if the poll answer is legitimate. This prevents fraudulent answers, and cross site voting.