### PR TITLE
update wp_polls_update_poll to use current poll id

### DIFF
--- a/polls-manager.php
+++ b/polls-manager.php
@@ -179,7 +179,7 @@ if(!empty($_POST['do'])) {
             // Update Lastest Poll ID To Poll Options
             $latest_pollid = polls_latest_id();
             $update_latestpoll = update_option('poll_latestpoll', $latest_pollid);
-            do_action( 'wp_polls_update_poll', $latest_pollid );
+            do_action( 'wp_polls_update_poll', $pollq_id );
             cron_polls_place();
             break;
     }


### PR DESCRIPTION
My company is using the **wp_polls_update_poll** action hook to add some custom fields, but we found when editing a poll, it always sends the latest poll id, when really we just want the current poll id being used.