### PR TITLE
Add check for CF-Connecting-IP header in get_ipaddress

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -721,7 +721,7 @@ function display_pollresult($poll_id, $user_voted = array(), $display_loading = 
 ### Function: Get IP Address
 if(!function_exists('get_ipaddress')) {
 	function get_ipaddress() {
-		foreach ( array( 'HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR' ) as $key ) {
+		foreach ( array( 'HTTP_CF_CONNECTING_IP', 'HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR' ) as $key ) {
 			if ( array_key_exists( $key, $_SERVER ) === true ) {
 				foreach ( explode( ',', $_SERVER[$key] ) as $ip ) {
 					$ip = trim( $ip );


### PR DESCRIPTION
CF-Connecting-IP is set by clouflare to the connecting client's IP address. By prioritizing this header over other headers, it is more difficult for a client to spoof their ip and vote multiple times.
https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-