### PR TITLE
Some template variables were not being replaced in the Poll Archive

### DIFF
--- a/wp-polls.php
+++ b/wp-polls.php
@@ -1061,9 +1061,9 @@ function polls_archive() {
 				'%POLL_ID%',
 				'%POLL_ANSWER_ID%',
 				'%POLL_ANSWER%',
-				'%POLL_ANSWER_TEXT%"',
+				'%POLL_ANSWER_TEXT%',
 				'%POLL_ANSWER_VOTES%',
-				'%POLL_ANSWER_PERCENTAGE%"',
+				'%POLL_ANSWER_PERCENTAGE%',
 				'%POLL_MULTIPLE_ANSWER_PERCENTAGE%',
 				'%POLL_ANSWER_IMAGEWIDTH%',
 			], [


### PR DESCRIPTION
This commit fixes a problem in the poll archive. The process of replacing template variables with the actual values was failing for some of them, as they were some double quotes that shouldn't be there