### PR TITLE
Add extra display functions for individual polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ I spent most of my free time creating, updating, maintaining and supporting thes
 <?php endif; ?> 
 ```
 
-### To Display Poll Timestamp by ID
+### To Display Poll Time by ID and date format
 
 ```php
-<?php if ( function_exists( 'get_polltimestamp' ) ): ?>
-	<?php get_polltimestamp($poll_id); ?>
+<?php if ( function_exists( 'get_polltime' ) ): ?>
+	<?php get_polltime($poll_id, $date_format); ?>
 <?php endif; ?>
 ```

--- a/README.md
+++ b/README.md
@@ -209,10 +209,26 @@ I spent most of my free time creating, updating, maintaining and supporting thes
 <?php endif; ?> 
 ```
  
+### To Display Poll Votes by ID
+
+```php
+<?php if ( function_exists( 'get_pollvotes_by_id' ) ): ?>
+	<?php get_pollvotes_by_id($poll_id); ?>
+<?php endif; ?>
+```
+
 ### To Display Total Poll Voters
 
 ```php
 <?php if ( function_exists( 'get_pollvoters' ) ): ?>
 	<?php get_pollvoters(); ?>
 <?php endif; ?> 
+```
+
+### To Display Poll Timestamp by ID
+
+```php
+<?php if ( function_exists( 'get_polltimestamp' ) ): ?>
+	<?php get_polltimestamp($poll_id); ?>
+<?php endif; ?>
 ```

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -881,11 +881,11 @@ if(!function_exists('get_pollvoters')) {
 
 ### Function: Get Poll Time Based on Poll ID and Date Format
 if(!function_exists('get_polltime')) {
-	function get_polltime($poll_id, $date_format = "d/m/Y", $display = true) {
+	function get_polltime($poll_id, $date_format = 'd/m/Y', $display = true) {
 		global $wpdb;
 		$poll_id = (int) $poll_id;
 		$timestamp = (int) $wpdb->get_var( $wpdb->prepare("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id));
-		$formatted_date = date($date_format,$timestamp);
+		$formatted_date = date( $date_format,$timestamp );
 		if($display) {
 			echo $formatted_date;
 		} else {

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -851,6 +851,20 @@ if(!function_exists('get_pollvotes')) {
 	}
 }
 
+### Function: Get Poll Votes Based on Poll ID
+if(!function_exists('get_pollvotes_by_id')) {
+	function get_pollvotes_by_id($poll_id, $display = true) {
+		global $wpdb;
+		$poll_id = (int) $poll_id;
+		$totalvotes = (int) $wpdb->get_var("SELECT pollq_totalvotes FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id);
+		if($display) {
+			echo $totalvotes;
+		} else {
+			return $totalvotes;
+		}
+	}
+}
+
 
 ### Function: Get Poll Total Voters
 if(!function_exists('get_pollvoters')) {
@@ -861,6 +875,20 @@ if(!function_exists('get_pollvoters')) {
 			echo $totalvoters;
 		} else {
 			return $totalvoters;
+		}
+	}
+}
+
+### Function: Get Poll Timestamp Based on Poll ID
+if(!function_exists('get_polltimestamp')) {
+	function get_pollvotes_by_id($poll_id, $display = true) {
+		global $wpdb;
+		$poll_id = (int) $poll_id;
+		$timestamp = (int) $wpdb->get_var("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id);
+		if($display) {
+			echo $timestamp;
+		} else {
+			return $timestamp;
 		}
 	}
 }

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -856,7 +856,7 @@ if(!function_exists('get_pollvotes_by_id')) {
 	function get_pollvotes_by_id($poll_id, $display = true) {
 		global $wpdb;
 		$poll_id = (int) $poll_id;
-		$totalvotes = (int) $wpdb->get_var("SELECT pollq_totalvotes FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id);
+		$totalvotes = (int) $wpdb->get_var( $wpdb->prepare("SELECT pollq_totalvotes FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id));
 		if($display) {
 			echo $totalvotes;
 		} else {
@@ -879,16 +879,17 @@ if(!function_exists('get_pollvoters')) {
 	}
 }
 
-### Function: Get Poll Timestamp Based on Poll ID
-if(!function_exists('get_polltimestamp')) {
-	function get_polltimestamp($poll_id, $display = true) {
+### Function: Get Poll Time Based on Poll ID and Date Format
+if(!function_exists('get_polltime')) {
+	function get_polltime($poll_id, $date_format = "d/m/Y", $display = true) {
 		global $wpdb;
 		$poll_id = (int) $poll_id;
-		$timestamp = (int) $wpdb->get_var("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id);
+		$timestamp = (int) $wpdb->get_var( $wpdb->prepare("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id));
+		$formatted_date = date($date_format,$timestamp);
 		if($display) {
-			echo $timestamp;
+			echo $formatted_date;
 		} else {
-			return $timestamp;
+			return $formatted_date;
 		}
 	}
 }

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -885,7 +885,7 @@ if(!function_exists('get_polltime')) {
 		global $wpdb;
 		$poll_id = (int) $poll_id;
 		$timestamp = (int) $wpdb->get_var( $wpdb->prepare("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id));
-		$formatted_date = date( $date_format,$timestamp );
+		$formatted_date = date( $date_format, $timestamp );
 		if($display) {
 			echo $formatted_date;
 		} else {

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -881,7 +881,7 @@ if(!function_exists('get_pollvoters')) {
 
 ### Function: Get Poll Timestamp Based on Poll ID
 if(!function_exists('get_polltimestamp')) {
-	function get_pollvotes_by_id($poll_id, $display = true) {
+	function get_polltimestamp($poll_id, $display = true) {
 		global $wpdb;
 		$poll_id = (int) $poll_id;
 		$timestamp = (int) $wpdb->get_var("SELECT pollq_timestamp FROM $wpdb->pollsq WHERE pollq_id = %d LIMIT 1", $poll_id);


### PR DESCRIPTION
This PR adds two extra functions for displaying information about a single poll

The first function displays the total number of poll votes for an individual poll given a poll ID, if the poll does not exist, 0 is returned

The second function displays the time an individual poll was posted. The function also accepts another parameter for the date format the user wants the posted date to return. If the poll does not exist, a date with the timestamp of 0 is returned (1st Jan 1970)

This PR also updates the README with the relevant functions