### PR TITLE
Filters for template variables to add custom variables if needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ wp_polls_template_resultbody_variables
 wp_polls_template_resultfooter_variables
 These can be used to register new variables on the admin side.
 Added readme documentation for the usage.
+* NEW: composer.json
 
 ### Version 2.75.5
  * NEW: New filter for templates: wp_polls_template_resultheader_markup, wp_polls_template_resultbody_markup, wp_polls_template_resultbody2_markup, wp_polls_template_resultfooter_markup, wp_polls_template_resultfooter2_markup. Props @Jaska.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ I spent most of my free time creating, updating, maintaining and supporting thes
 ## Changelog
 
 ### Version 2.75.6
- * NEW: New filter for template variables: wp_polls_template_resultheader_variables, wp_polls_template_resultbody_variables, wp_polls_template_resultfooter_variables, wp_polls_template_resultfooter2_variables. These can be used to register new variables on the admin side.
+ * NEW: New filter for template variables: wp_polls_template_resultheader_variables, wp_polls_template_resultbody_variables, wp_polls_template_resultfooter_variables. These can be used to register new variables on the admin side.
 
 ### Version 2.75.5
  * NEW: New filter for templates: wp_polls_template_resultheader_markup, wp_polls_template_resultbody_markup, wp_polls_template_resultbody2_markup, wp_polls_template_resultfooter_markup, wp_polls_template_resultfooter2_markup. Props @Jaska.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ I spent most of my free time creating, updating, maintaining and supporting thes
 ## Changelog
 
 ### Version 2.75.6
- * NEW: New filter for template variables: wp_polls_template_resultheader_variables, wp_polls_template_resultbody_variables, wp_polls_template_resultfooter_variables. These can be used to register new variables on the admin side.
+ * NEW: New filter for template variables:
+wp_polls_template_votebody_variables
+wp_polls_template_votefooter
+wp_polls_template_resultheader_variables
+wp_polls_template_resultbody_variables
+wp_polls_template_resultfooter_variables
+These can be used to register new variables on the admin side.
+Added readme documentation for the usage.
 
 ### Version 2.75.5
  * NEW: New filter for templates: wp_polls_template_resultheader_markup, wp_polls_template_resultbody_markup, wp_polls_template_resultbody2_markup, wp_polls_template_resultfooter_markup, wp_polls_template_resultfooter2_markup. Props @Jaska.
@@ -244,3 +251,38 @@ I spent most of my free time creating, updating, maintaining and supporting thes
 	<?php get_polltime( $poll_id, $date_format ); ?>
 <?php endif; ?>
 ```
+
+### Translating the template
+
+The plugin templates can be translated via template variables.
+There are these filters for the custom template variables
+```
+wp_polls_template_votebody_variables
+wp_polls_template_votefooter
+wp_polls_template_resultheader_variables
+wp_polls_template_resultbody_variables
+wp_polls_template_resultfooter_variables
+```
+
+Add filter to your theme and register custom variable where you will add your translation.
+Good practice is to name them for example with prefix `STR_` here `STR_TOTAL_VOTERS`.
+```php
+    /**
+     * Localize wp_polls_template_resultfooter_variables.
+     *
+     * @param array $variables An array of template variables.
+     * @return array $variables Modified template variables.
+     */
+    function wp_polls_template_resultfooter_variables( $variables ) {
+
+        // Add strings.
+        $variables['%STR_TOTAL_VOTERS%'] = __( 'Total voters', 'theme-textdomain' );
+
+        return $variables;
+    }
+
+// Trigger the filter
+\add_filter( 'wp_polls_template_resultfooter_variables', 'wp_polls_template_resultfooter_variables' , 10, 1 );
+```
+In the admin side just call the custom variable like so and it works and the variable has been translated.
+`%STR_TOTAL_VOTERS%'`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ WP-Polls is extremely customizable via templates and css styles and there are to
 I spent most of my free time creating, updating, maintaining and supporting these plugins, if you really love my plugins and could spare me a couple of bucks, I will really appreciate it. If not feel free to use it without any obligations.
 
 ## Changelog
+
+### Version 2.75.6
+ * NEW: New filter for template variables: wp_polls_template_resultheader_variables, wp_polls_template_resultbody_variables, wp_polls_template_resultfooter_variables, wp_polls_template_resultfooter2_variables. These can be used to register new variables on the admin side.
+
 ### Version 2.75.5
  * NEW: New filter for templates: wp_polls_template_resultheader_markup, wp_polls_template_resultbody_markup, wp_polls_template_resultbody2_markup, wp_polls_template_resultfooter_markup, wp_polls_template_resultfooter2_markup. Props @Jaska.
 

--- a/README.md
+++ b/README.md
@@ -284,5 +284,5 @@ Good practice is to name them for example with prefix `STR_` here `STR_TOTAL_VOT
 // Trigger the filter
 \add_filter( 'wp_polls_template_resultfooter_variables', 'wp_polls_template_resultfooter_variables' , 10, 1 );
 ```
-In the admin side just call the custom variable like so and it works and the variable has been translated.
+In the admin side just call the custom variable like so and the variable has been translated in the front-end.
 `%STR_TOTAL_VOTERS%'`

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ wp_polls_template_resultfooter_variables
 ```
 
 Add filter to your theme and register custom variable where you will add your translation.
-Good practice is to name them for example with prefix `STR_` here `STR_TOTAL_VOTERS`.
+Good practice is to name them for example with prefix `STR_` in the example `STR_TOTAL_VOTERS`.
 ```php
     /**
      * Localize wp_polls_template_resultfooter_variables.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "lesterchan/wp-polls",
+    "description": "Adds an AJAX poll system to your WordPress blog.",
+    "type": "wordpress-plugin",
+    "keywords": ["wordpress", "plugin", "poll"],
+    "license": ["GPL-2.0-only"],
+    "minimum-stability": "dev",
+    "authors": [
+      {
+        "name": "Lester Chan",
+        "email": "lesterchan@gmail.com"
+      }
+    ],
+    "repositories": [
+      {
+        "type":"composer",
+        "url":"https://wpackagist.org"
+      }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
     "license": ["GPL-2.0-only"],
     "minimum-stability": "dev",
     "authors": [
-      {
-        "name": "Lester Chan",
-        "email": "lesterchan@gmail.com"
-      }
+        {
+            "name": "Lester Chan",
+            "email": "lesterchan@gmail.com"
+        }
     ],
     "repositories": [
-      {
-        "type":"composer",
-        "url":"https://wpackagist.org"
-      }
+        {
+            "type":"composer",
+            "url":"https://wpackagist.org"
+        }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,5 @@
             "name": "Lester Chan",
             "email": "lesterchan@gmail.com"
         }
-    ],
-    "repositories": [
-        {
-            "type":"composer",
-            "url":"https://wpackagist.org"
-        }
     ]
 }

--- a/wp-polls.php
+++ b/wp-polls.php
@@ -445,15 +445,18 @@ function display_pollvote($poll_id, $display_loading = true) {
 
 	$template_question = removeslashes(get_option('poll_template_voteheader'));
 
-	$template_question = apply_filters( 'wp_polls_template_voteheader_markup', $template_question, $poll_question, array(
-		'%POLL_QUESTION%' => $poll_question_text,
-		'%POLL_ID%' => $poll_question_id,
-		'%POLL_TOTALVOTES%' => $poll_question_totalvotes,
-		'%POLL_TOTALVOTERS%' => $poll_question_totalvoters,
-		'%POLL_START_DATE%' => $poll_start_date,
-		'%POLL_END_DATE%' => $poll_end_date,
-		'%POLL_MULTIPLE_ANS_MAX%' => $poll_multiple_ans > 0 ? $poll_multiple_ans : 1
-	) );
+	$template_question_variables = array(
+		'%POLL_QUESTION%' 		  	=> $poll_question_text,
+		'%POLL_ID%' 			  	=> $poll_question_id,
+		'%POLL_TOTALVOTES%' 	  	=> $poll_question_totalvotes,
+		'%POLL_TOTALVOTERS%' 		=> $poll_question_totalvoters,
+		'%POLL_START_DATE%' 		=> $poll_start_date,
+		'%POLL_END_DATE%' 			=> $poll_end_date,
+		'%POLL_MULTIPLE_ANS_MAX%'   => $poll_multiple_ans > 0 ? $poll_multiple_ans : 1
+	);
+	$template_question_variables = apply_filters( 'wp_polls_template_voteheader_variables', $template_question_variables );
+	$template_question  		 = apply_filters( 'wp_polls_template_voteheader_markup', $template_question, $poll_question, $template_question_variables );
+	
 
 	// Get Poll Answers Data
 	list($order_by, $sort_order) = _polls_get_ans_sort();
@@ -479,15 +482,18 @@ function display_pollvote($poll_id, $display_loading = true) {
 			$poll_multiple_answer_percentage = $poll_question_totalvoters > 0 ? round( ( $poll_answer_votes / $poll_question_totalvoters ) * 100 ) : 0;
 			$template_answer = removeslashes( get_option( 'poll_template_votebody' ) );
 
-			$template_answer = apply_filters( 'wp_polls_template_votebody_markup', $template_answer, $poll_answer, array(
-				'%POLL_ID%' => $poll_question_id,
-				'%POLL_ANSWER_ID%' => $poll_answer_id,
-				'%POLL_ANSWER%' => $poll_answer_text,
-				'%POLL_ANSWER_VOTES%' => number_format_i18n( $poll_answer_votes ),
-				'%POLL_ANSWER_PERCENTAGE%' => $poll_answer_percentage,
+			$template_answer_variables = array(
+				'%POLL_ID%' 						=> $poll_question_id,
+				'%POLL_ANSWER_ID%' 					=> $poll_answer_id,
+				'%POLL_ANSWER%' 					=> $poll_answer_text,
+				'%POLL_ANSWER_VOTES%' 				=> number_format_i18n( $poll_answer_votes ),
+				'%POLL_ANSWER_PERCENTAGE%' 			=> $poll_answer_percentage,
 				'%POLL_MULTIPLE_ANSWER_PERCENTAGE%' => $poll_multiple_answer_percentage,
-				'%POLL_CHECKBOX_RADIO%' => $poll_multiple_ans > 0 ? 'checkbox' : 'radio'
-			) );
+				'%POLL_CHECKBOX_RADIO%' 			=> $poll_multiple_ans > 0 ? 'checkbox' : 'radio',
+			);
+		
+			$template_answer_variables = apply_filters( 'wp_polls_template_votebody_variables', $template_answer_variables );
+			$template_answer 		   = apply_filters( 'wp_polls_template_votebody_markup', $template_answer, $poll_answer, $template_answer_variables );
 
 			// Print Out Voting Form Body Template
 			$temp_pollvote .= "\t\t$template_answer\n";
@@ -505,13 +511,16 @@ function display_pollvote($poll_id, $display_loading = true) {
 		// Voting Form Footer Variables
 		$template_footer = removeslashes(get_option('poll_template_votefooter'));
 
-		$template_footer = apply_filters( 'wp_polls_template_votefooter_markup', $template_footer, $poll_question, array(
+		$template_footer_variables = array(
 			'%POLL_ID%' => $poll_question_id,
 			'%POLL_RESULT_URL%' => $poll_result_url,
 			'%POLL_START_DATE%' => $poll_start_date,
 			'%POLL_END_DATE%' => $poll_end_date,
 			'%POLL_MULTIPLE_ANS_MAX%' => $poll_multiple_ans > 0 ? $poll_multiple_ans : 1
-		) );
+		);
+	
+		$template_footer_variables = apply_filters( 'wp_polls_template_votefooter_variables', $template_footer_variables );
+		$template_footer 		   = apply_filters( 'wp_polls_template_votefooter_markup', $template_footer, $poll_question, $template_footer_variables );
 
 		// Print Out Voting Form Footer Template
 		$temp_pollvote .= "\t\t$template_footer\n";
@@ -585,7 +594,8 @@ function display_pollresult( $poll_id, $user_voted = array(), $display_loading =
 		'%POLL_END_DATE%' => $poll_end_date
 	);
 
-	$template_question = apply_filters('wp_polls_template_resultheader_markup', $template_question, $poll_question, $template_variables);
+	$template_variables = apply_filters('wp_polls_template_resultheader_variables', $template_variables );
+	$template_question  = apply_filters('wp_polls_template_resultheader_markup', $template_question, $poll_question, $template_variables );
 
 	if($poll_multiple_ans > 0) {
 		$template_question = str_replace( '%POLL_MULTIPLE_ANS_MAX%', $poll_multiple_ans, $template_question );
@@ -645,6 +655,8 @@ function display_pollresult( $poll_id, $user_voted = array(), $display_loading =
 				'%POLL_MULTIPLE_ANSWER_PERCENTAGE%' => $poll_multiple_answer_percentage,
 				'%POLL_ANSWER_IMAGEWIDTH%' => $poll_answer_imagewidth
 			);
+			$template_variables = apply_filters('wp_polls_template_resultbody_variables', $template_variables);
+
 			// Let User See What Options They Voted
 			if ( in_array( $poll_answer_id, $user_voted, true ) ) {
 				// Results Body Variables
@@ -689,6 +701,8 @@ function display_pollresult( $poll_id, $user_voted = array(), $display_loading =
 			'%POLL_LEAST_VOTES%' => number_format_i18n( $poll_least_votes ),
 			'%POLL_LEAST_PERCENTAGE%' => $poll_least_percentage
 		);
+		$template_variables = apply_filters('wp_polls_template_resultfooter_variables', $template_variables );
+
 		if ( ! empty( $user_voted ) || $poll_question_active === 0 || ! check_allowtovote() ) {
 			$template_footer = removeslashes( get_option( 'poll_template_resultfooter' ) );
 			$template_footer = apply_filters('wp_polls_template_resultfooter_markup', $template_footer, $poll_question, $template_variables);


### PR DESCRIPTION
Noticed that translations can't be done with this plugin without modifying the plugin.

I added some filters for the plugin like so.

After this you can register translations in the php side. Here is an example for that.
Filter in theme
```
    /**
     * Localize wp_polls_template_resultfooter_variables.
     *
     * @param array $variables An array of template variables.
     * @return array $variables Modified template variables.
     */
    function wp_polls_template_resultfooter_variables( $variables ) {

        // Add strings.
        $variables['%STR_TOTAL_VOTERS%'] = __( 'Total voters', 'theme-textdomain' );

        return $variables;
    }

// Trigger the filter
\add_filter( 'wp_polls_template_resultfooter_variables', 'wp_polls_template_resultfooter_variables' , 10, 1 );
```

In the admin side just call the custom variable like so and it works and the variable has been translated.
```
%STR_TOTAL_VOTERS%'
```

Maybe it would be better that all the parts would be php-templates but that would need a lot of refactoring. This is maybe the easiest workaround for the translations for now. These filters could be used of course for anything else but are handy also for the translations.

I hope this helps you too. 👍 